### PR TITLE
Update and rename undz.py to undies.py

### DIFF
--- a/undies.py
+++ b/undies.py
@@ -23,7 +23,8 @@ import os
 import sys
 import io
 import zlib
-import zstandard as zstd
+# import zstandard as zstd
+import zstd
 import argparse
 import hashlib
 from binascii import crc32, b2a_hex


### PR DESCRIPTION
after poking around it seems like the original undz.py file imports a variation of zstd, "zstandard". i went about fixing the resulting error in an obtuse way, attempting to install a few different packages via pip, apt, etc. at some point i had a "duh" moment and simply changed the undz file to import zstd, instead of importing zstandard as zstd. 

i figured creating a new file might make this process a bit less murky for folks who, like me, are trying to work with the somewhat dismal LG tools to fix, setup, root, or just play around with their phone - but possess little to no knowledge of any actual programming languages 

might throw some language in the readme along the lines of "if you get the zstd error, re-run the command using undies file in place of undz" 

and yes, i pronounce "undz" in my head just like the shortened/slang term for "underwear", hence, undies.