### PR TITLE
undz: remove print of warning

### DIFF
--- a/undz.py
+++ b/undz.py
@@ -87,8 +87,6 @@ class UNDZUtils(object):
                 # To my knowledge this is supposed to be blank (for now...)
                 if len(dz_item['pad']) != 0:
                         print("[!] Warning: pad is not empty", file=sys.stderr)
-                        print("[!] pad contains: " + dz_item['pad'].decode(), file=sys.stderr)
-
 
                 return dz_item
 


### PR DESCRIPTION
* V500N20b_00_KT_KR_OP_1223 throws an error, that some characters cant be encoded with utf8
* just remove the print of the warning, as it doesnt affect extraction